### PR TITLE
Allow for manual account config and other changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Google Calendar in GNOME Shell
 This version of gnome-shell-google-calendar is forked from vintitres's version.  This version is intended to allow easier installation to debian based platforms.
 
 Installation
-=========
+============
 
 ## Using .deb files
 Installation using deb files is relatively easy.  Simply run the following commands:
@@ -22,18 +22,20 @@ After you answer the initial question you may ^C out of the script and log out t
 
 
 Excluding Calendars
-==============
-If you would like to exclude some calendars from showing up you should add them to ~/.gnome-shell-google-calendar-excludes with one entry per line.
+===================
+If you would like to exclude some calendars from showing up you should add them to ~/.config/gnome-shell-google-calendar/excludes with one entry per line.
 
 Changes from vintitres's version
-========================
+================================
 
-There aren't a huge amount of changes from vintitres's version, but I'll list them here:
+There aren't a huge amount of changes from vintitres's version, but the major one are:
 
-First, I've changed the place where the config.json file is saved.  By default it seems to be cwd, but this version saves them in ~/.config/gnome-shell-google-calendar.
+* The place where the config.json file is saved has been.  By default it seems to be cwd, but this version saves them in ~/.config/gnome-shell-google-calendar.
 
-I've made it to where exclusions can be loaded from /etc/gnome-shell-google-calendar/excludes if they aren't found in the user's directory.
+* Exclusions can be loaded from /etc/gnome-shell-google-calendar/excludes if they aren't found in the user's directory.
 
-I've made it to where the main executable can include from the /usr/lib/gnome-shell-google-calendar directory, in order to facilitate a an installation to /usr/bin
+* Main executable can include from the /usr/lib/gnome-shell-google-calendar directory, in order to facilitate a an installation to /usr/bin
 
-I've added an autostart script that can be used when gnome-shell-google-calendar.py is installed to /usr/bin
+* Added an autostart script that can be used when gnome-shell-google-calendar.py is installed to /usr/bin
+
+* Given an option to use login details directly from config.json, rather than from GNOME Online accounts

--- a/config.py
+++ b/config.py
@@ -6,20 +6,21 @@ Created on 17.02.2012
 import json
 import os
 
-config_dir = os.getenv('HOME') + '/.config/gnome-shell-google-calendar'
+local_config_dir = os.getenv('HOME') + '/.config/gnome-shell-google-calendar/'
+global_config_dir = '/etc/gnome-shell-google-calendar/'
 
 def set(parameter, value):
     config = get(None)
     config[parameter] = value
-    if not os.path.exists(config_dir):
-      os.makedirs(config_dir)
-    with open(config_dir + '/config.json', 'w') as fp:
+    if not os.path.exists(local_config_dir):
+      os.makedirs(local_config_dir)
+    with open(local_config_dir + 'config.json', 'w') as fp:
         json.dump(config, fp)
 
 
 def get(parameter):
     try:
-        with open(config_dir + '/config.json', 'r') as fp:
+        with open(local_config_dir + 'config.json', 'r') as fp:
             config = json.load(fp)
     except:
         config = dict()

--- a/gnome-shell-google-calendar.py
+++ b/gnome-shell-google-calendar.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 import codecs
 import sys

--- a/gnome-shell-google-calendar.py
+++ b/gnome-shell-google-calendar.py
@@ -31,10 +31,17 @@ debug = False
 SHOW_SHORT_CALENDAR_TITLE = True
 GET_ACCOUNT_FROM_CONFIG = False
 HELP_STRING = ''' 
-  Options:
-   --help          Show this help
-   --hide-cal          Do not show Calendar Identification beside events
-   --manual-account    Get Account Details from the config file rather than from Gnome Online Accounts 
+Options:
+    --help              Show this help
+    --hide-cal          Do not show Calendar Identification beside events
+    --manual-account    Get Account Details from the config file rather than from Gnome Online Accounts. 
+
+Local Config directory: ''' + config.local_config_dir + '''
+
+Keys in config.json:
+    * manual    - Setting to "true" has the same effect as --manual-accout command-line option.
+    * account   - The Google Account for which calendars are fetched
+    * password  - The Account password (If 2-factor authentication is enabled, this needs to be an app-specific password)
  '''
 
 def write_traceback(f):
@@ -472,9 +479,11 @@ if __name__ == '__main__':
             print (HELP_STRING)
             sys.exit (0)
             
-
     if not account:
         account = config.get('account')
+
+    if config.get('manual') == 'true':
+        GET_ACCOUNT_FROM_CONFIG = True
 
     # Login
     client = None

--- a/gnome-shell-google-calendar.py
+++ b/gnome-shell-google-calendar.py
@@ -268,7 +268,7 @@ class CalendarServer(dbus.service.Object):
         # Load excluded calendars from excludes file
         excludes = set()
         for filename in ('excludes',
-                os.path.expanduser('~/.gnome-shell-google-calendar-excludes'), '/etc/gnome-shell-google-calendar/excludes'):
+                os.path.expanduser(config.local_config_dir +  'excludes'), config.global_config_dir + 'excludes'):
             if os.path.exists(filename):
                 excludes |= self.get_excludes(filename)
 
@@ -483,7 +483,7 @@ if __name__ == '__main__':
         password = config.get('password')
         if account is None or account == '' or password is None or password is '':
             print 'Account details not setup'
-            print 'Please setup the details at ~/.config/gnome-shell-google-calendar/config.json'
+            print 'Please setup the details at ' + config.local_config_dir + 'config.json'
             sys.exit (1)
         try:  
             client = gdata.calendar.client.CalendarClient(source='gnome-shell-google-calendar')

--- a/gnome-shell-google-calendar.py
+++ b/gnome-shell-google-calendar.py
@@ -30,6 +30,12 @@ debug = False
 
 SHOW_SHORT_CALENDAR_TITLE = True
 GET_ACCOUNT_FROM_CONFIG = False
+HELP_STRING = ''' 
+  Options:
+   --help          Show this help
+   --hide-cal          Do not show Calendar Identification beside events
+   --manual-account    Get Account Details from the config file rather than from Gnome Online Accounts 
+ '''
 
 def write_traceback(f):
     '''Wrapper that catches any tracebacks that are found and writes them to
@@ -451,7 +457,7 @@ class CalendarServer(dbus.service.Object):
 if __name__ == '__main__':
     dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
 
-    opts, args = getopt.getopt(sys.argv[1:], '', ['hide-cal', 'account=', 'manual-account'])
+    opts, args = getopt.getopt(sys.argv[1:], '', ['hide-cal', 'account=', 'manual-account', 'help'])
     account = None
     password = None
 
@@ -462,6 +468,10 @@ if __name__ == '__main__':
             account = a
         if o == '--manual-account':
             GET_ACCOUNT_FROM_CONFIG = True
+        if o == '--help':
+            print (HELP_STRING)
+            sys.exit (0)
+            
 
     if not account:
         account = config.get('account')


### PR DESCRIPTION
- Ensure the script runs with python2
- Option to use manual account details
- Move excludes file to .config directory, same as config.json
- Add help string
